### PR TITLE
fix(heap_corruption): that caused LoadProhibited, StoreProhibited errors

### DIFF
--- a/src/LV_Helper_v9.cpp
+++ b/src/LV_Helper_v9.cpp
@@ -29,7 +29,7 @@ static void disp_flush( lv_display_t *disp_drv, const lv_area_t *area, uint8_t *
     uint32_t w = ( area->x2 - area->x1 + 1 );
     uint32_t h = ( area->y2 - area->y1 + 1 );
     auto *plane = (LilyGo_Display *)lv_display_get_user_data(disp_drv);
-    lv_draw_sw_rgb565_swap(color_p, w * h * 2);
+    lv_draw_sw_rgb565_swap(color_p, w * h);
     plane->pushColors(area->x1, area->y1, w, h, (uint16_t *)color_p);
     lv_display_flush_ready( disp_drv );
 }


### PR DESCRIPTION
I making a project with lvgl v9 and using S3-AMOLED 1.91 . I already did the upgrade steps (rename lv_conf.h files).
Often I ran into a Guru Meditation, [StoreProhibited](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/fatal-errors.html#loadprohibited-storeprohibited) Heap corruption error. I thought my code had a problem, but after many hours of debugging I know what causes it.

[LV_Helper_v9.cpp](https://github.com/Xinyuan-LilyGO/LilyGo-AMOLED-Series/blob/master/src/LV_Helper_v9.cpp) file at line 32: it swaps color channels to accurately paint the colors, BUT the second parameter to the function is `h*w*2` which is outside of the original buffer area `h*w`.

Steps to reproduce, log heap corruption:

1.  `git clone https://github.com/KerteszRoland/LilyGo-AMOLED-Series/tree/reproduce` (already switched to lvgl v9, loaded v9 example, added debuging logs)
2.  Compile, Upload with platformio
3.  Click Serial Monitor
4.  Should look like this: 
<img width="602" height="205" alt="image" src="https://github.com/user-attachments/assets/795879da-0f0d-48ec-9398-3ed6085c0b44" />


After fix: 
<img width="335" height="121" alt="image" src="https://github.com/user-attachments/assets/dd2839b3-cf6e-4992-8c20-d27681018fee" />


